### PR TITLE
Allow offset in terms of float

### DIFF
--- a/src/gpicsync.py
+++ b/src/gpicsync.py
@@ -303,7 +303,7 @@ if __name__=="__main__":
     print "\n"
 
     geo=GpicSync(gpxFile=options.gpx,
-    tcam_l=options.tcam,tgps_l=options.tgps,UTCoffset=int(options.offset),timerange=int(options.timerange),timezone=options.timezone,
+    tcam_l=options.tcam,tgps_l=options.tgps,UTCoffset=float(options.offset),timerange=int(options.timerange),timezone=options.timezone,
     qr_time_image=options.qr_time_image)
 
     files = list(getFileList(options.dir))


### PR DESCRIPTION
Some time zones are non integer. For example, India is +5:30 while Nepal is +5:45. The allows for timezones to be set at 5.5 and Nepal as 5.75. Although not a clean at 5:30 (the official way to write it), it seems sufficient.